### PR TITLE
Fixed group name to agents_permission in user creation function

### DIFF
--- a/services/keycloakService.js
+++ b/services/keycloakService.js
@@ -1073,7 +1073,7 @@ class KeycloakService extends Keycloak {
     async createUser(username, password, token, userRoles) {
 
         let assignRole = [];
-        let assignGroups = ['agents', 'default'];
+        let assignGroups = ['agents_permission', 'default'];
 
         return new Promise(async (resolve, reject) => {
 
@@ -1121,7 +1121,7 @@ class KeycloakService extends Keycloak {
                         temporary: false
                     }
                 ],
-                groups: ["agents", "default"]
+                groups: ["agents_permission", "default"]
             }
 
             let config = {


### PR DESCRIPTION
Fixed group name to agents_permission  from agents according to our new naming convention for AgentDesk Permission Groups