### PR TITLE
Handling of 404 error when no teamId is found in getGroupMembers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ef-keycloak-connect",
-  "version": "1.6.0",
+  "version": "1.5.2",
   "description": "Node JS keycloak adapter for authentication and authorization.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Handling of 404 error when no teamId is found in getGroupMembers function, Now the loop get other groups data against groupId if one of the given id has no group against it. If all provided groupIds has no group against it then we return an empty array.

Also, the implementation of Teams with Permissions/Policies has been commented out for now. 